### PR TITLE
Disable fail-fast on matrix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -97,6 +97,7 @@ jobs:
     strategy:
       matrix:
         TESTNAME: [auto, basic]
+      fail-fast: false  
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR ensures that all test units are ececuted completely instead of being aborted when the first test unit reports failed tests.