### PR TITLE
Update LightControl.vttmake

### DIFF
--- a/ECU/LightControl.vttmake
+++ b/ECU/LightControl.vttmake
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 
-<BuildSpecification schemaVersion="6.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="VttMakeFileSchema_4_0.xsd">
+<BuildSpecification schemaVersion="6.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="VttMakeFileSchema_6_0.xsd">
     <BuildDpa>
         <BuildSettings>
             <CANoeEmuPathOption>VTTInstallation</CANoeEmuPathOption>

--- a/ECU/LightControl.vttmake
+++ b/ECU/LightControl.vttmake
@@ -1,6 +1,6 @@
-﻿<?xml version="6.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 
-<BuildSpecification schemaVersion="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="VttMakeFileSchema_4_0.xsd">
+<BuildSpecification schemaVersion="6.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="VttMakeFileSchema_4_0.xsd">
     <BuildDpa>
         <BuildSettings>
             <CANoeEmuPathOption>VTTInstallation</CANoeEmuPathOption>

--- a/ECU/LightControl.vttmake
+++ b/ECU/LightControl.vttmake
@@ -2,6 +2,9 @@
 
 <BuildSpecification schemaVersion="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="VttMakeFileSchema_4_0.xsd">
     <BuildDpa>
+        <BuildSettings>
+            <CANoeEmuPathOption>VTTInstallation</CANoeEmuPathOption>
+        </BuildSettings>
         <DpaPath>LightControl.dpa</DpaPath>
         <!-- Generates the code of all RTE modules in Vector DaVinci Configurator. -->
         <GenerateRte />

--- a/ECU/LightControl.vttmake
+++ b/ECU/LightControl.vttmake
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="6.0" encoding="utf-8" ?>
 
 <BuildSpecification schemaVersion="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="VttMakeFileSchema_4_0.xsd">
     <BuildDpa>

--- a/ECU/LightControl.vttmake
+++ b/ECU/LightControl.vttmake
@@ -33,5 +33,4 @@
         </BuildVsSolution>
         <GenerateZip />
     </BuildDpa>
-
 </BuildSpecification>

--- a/environment-make/venvironment.yaml
+++ b/environment-make/venvironment.yaml
@@ -1,5 +1,5 @@
 
-version: 3.0.0
+version: 3.1.0
 
 system-variables:
   - file-path: SysVar/interface.vsysvar


### PR DESCRIPTION
Got rid of the warning in environment-make due to updated canoe4sw-se version